### PR TITLE
Stardrop adjustments

### DIFF
--- a/Autosplitters/Stardrio.asl
+++ b/Autosplitters/Stardrio.asl
@@ -1,27 +1,25 @@
-state("Stardrop"){}
+state("Stardrop") { }
 
 startup
 {
     Assembly.Load(File.ReadAllBytes("Components/asl-help")).CreateInstance("Unity");
-    vars.Helper.GameName = "Stardrop";
     vars.Helper.LoadSceneManager = true;
-}
-
-start
-{
-    return current.activeScene == "Stage1";
-}
-
-reset
-{
-    return current.activeScene == "Stage0";
 }
 
 update
 {
-    current.activeScene = vars.Helper.Scenes.Active.Name == null ? current.activeScene : vars.Helper.Scenes.Active.Name;
-    current.loadingScene = vars.Helper.Scenes.Loaded[0].Name == null ? current.loadingScene : vars.Helper.Scenes.Loaded[0].Name;
+    current.Scene = vars.Helper.Scenes.Active.Name ?? current.Scene;
 
-    if(current.activeScene != old.activeScene) vars.Log("active: Old: \"" + old.activeScene + "\", Current: \"" + current.activeScene + "\"");
-    if(current.loadingScene != old.loadingScene) vars.Log("loading: Old: \"" + old.loadingScene + "\", Current: \"" + current.loadingScene + "\"");
+    // if (old.Scene != current.Scene)
+    //     vars.Log("Scene: " + old.Scene + " -> " + current.Scene);
+}
+
+start
+{
+    return old.Scene != "Stage1" && current.Scene == "Stage1";
+}
+
+reset
+{
+    return old.Scene != "Stage0" && current.Scene == "Stage0";
 }


### PR DESCRIPTION
`loadingScene` is unused.  
Check against `old` to prevent starting/resetting on every frame.  
Simplify `current.Scene` null check.  
`GameName` is identical to process name.